### PR TITLE
Add shift API integration and status screen updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,6 +14,7 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "SHIFT_API_BASE_URL", "\"https://cloudmonkeycoding.com/Cindys-Bakeshop/PHP/\"")
     }
 
     buildTypes {
@@ -29,6 +30,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {
@@ -39,6 +43,9 @@ dependencies {
     implementation(libs.constraintlayout)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth)
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.converter.gson)
+    implementation(libs.okhttp.logging)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/deliveryapp/StatusActivity.java
+++ b/app/src/main/java/com/example/deliveryapp/StatusActivity.java
@@ -1,14 +1,294 @@
 package com.example.deliveryapp;
 
 import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
+
+import com.example.deliveryapp.network.ShiftRepository;
+import com.example.deliveryapp.network.model.ShiftSchedule;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
 public class StatusActivity extends BottomNavActivity {
+
+    private static final SimpleDateFormat SERVER_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+    private static final SimpleDateFormat SERVER_TIME_FORMAT = new SimpleDateFormat("HH:mm", Locale.US);
+    private static final SimpleDateFormat MONTH_FORMAT = new SimpleDateFormat("MMM", Locale.US);
+    private static final SimpleDateFormat DAY_FORMAT = new SimpleDateFormat("d", Locale.US);
+    private static final SimpleDateFormat WEEKDAY_FORMAT = new SimpleDateFormat("EEE", Locale.US);
+    private static final SimpleDateFormat DISPLAY_TIME_FORMAT = new SimpleDateFormat("h:mm a", Locale.US);
+
+    private TextView statusBanner;
+    private View shiftCard;
+    private TextView shiftEmptyState;
+    private TextView shiftMonthLabel;
+    private TextView shiftDayLabel;
+    private TextView shiftWeekdayLabel;
+    private TextView shiftTimeRange;
+    private TextView shiftLocationLabel;
+    private TextView shiftCountdownLabel;
+    private Button shiftActionButton;
+    private ProgressBar loadingIndicator;
+
+    private final ShiftRepository shiftRepository = new ShiftRepository();
+    @Nullable
+    private ShiftSchedule currentShift;
+    private boolean actionInProgress;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_status);
         setupBottomNavigation(R.id.menu_status);
+
+        statusBanner = findViewById(R.id.statusBanner);
+        shiftCard = findViewById(R.id.shiftCard);
+        shiftEmptyState = findViewById(R.id.shiftEmptyState);
+        shiftMonthLabel = findViewById(R.id.shiftMonthLabel);
+        shiftDayLabel = findViewById(R.id.shiftDayLabel);
+        shiftWeekdayLabel = findViewById(R.id.shiftWeekdayLabel);
+        shiftTimeRange = findViewById(R.id.shiftTimeRange);
+        shiftLocationLabel = findViewById(R.id.shiftLocationLabel);
+        shiftCountdownLabel = findViewById(R.id.shiftCountdownLabel);
+        shiftActionButton = findViewById(R.id.btnShiftAction);
+        loadingIndicator = findViewById(R.id.shiftLoadingIndicator);
+
+        shiftActionButton.setOnClickListener(v -> {
+            if (currentShift == null) {
+                Toast.makeText(this, R.string.status_no_shift, Toast.LENGTH_SHORT).show();
+                return;
+            }
+            if (actionInProgress) {
+                return;
+            }
+            if (currentShift.isInProgress()) {
+                endCurrentShift();
+            } else {
+                startCurrentShift();
+            }
+        });
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        loadUpcomingShift();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        shiftRepository.cancelAll();
+    }
+
+    private void loadUpcomingShift() {
+        setLoading(true);
+        shiftRepository.fetchUpcomingShift(null, new ShiftRepository.ShiftLoadCallback() {
+            @Override
+            public void onSuccess(@Nullable ShiftSchedule upcomingShift) {
+                setLoading(false);
+                currentShift = upcomingShift;
+                shiftEmptyState.setText(R.string.status_no_shift);
+                updateUiForShift(upcomingShift);
+            }
+
+            @Override
+            public void onError(String message) {
+                setLoading(false);
+                currentShift = null;
+                updateUiForShift(null);
+                shiftEmptyState.setText(R.string.status_loading_error);
+                shiftEmptyState.setVisibility(View.VISIBLE);
+                Toast.makeText(StatusActivity.this, R.string.status_loading_error, Toast.LENGTH_LONG).show();
+            }
+        });
+    }
+
+    private void startCurrentShift() {
+        if (currentShift == null) {
+            return;
+        }
+        setActionInProgress(true);
+        shiftRepository.startShift(currentShift.getShiftId(), (success, message) -> {
+            setActionInProgress(false);
+            Toast.makeText(
+                    StatusActivity.this,
+                    message != null ? message : (success
+                            ? getString(R.string.status_shift_in_progress_message)
+                            : getString(R.string.status_loading_error)),
+                    Toast.LENGTH_SHORT
+            ).show();
+            if (success) {
+                loadUpcomingShift();
+            }
+        });
+    }
+
+    private void endCurrentShift() {
+        if (currentShift == null) {
+            return;
+        }
+        setActionInProgress(true);
+        shiftRepository.endShift(currentShift.getShiftId(), (success, message) -> {
+            setActionInProgress(false);
+            Toast.makeText(
+                    StatusActivity.this,
+                    message != null ? message : (success
+                            ? getString(R.string.status_shift_completed_message)
+                            : getString(R.string.status_loading_error)),
+                    Toast.LENGTH_SHORT
+            ).show();
+            if (success) {
+                loadUpcomingShift();
+            }
+        });
+    }
+
+    private void updateUiForShift(@Nullable ShiftSchedule shift) {
+        if (shift == null) {
+            statusBanner.setText(R.string.status_banner_not_working);
+            shiftCard.setVisibility(View.GONE);
+            shiftEmptyState.setVisibility(View.VISIBLE);
+            shiftActionButton.setText(R.string.status_start_shift);
+            shiftActionButton.setEnabled(false);
+            return;
+        }
+
+        shiftCard.setVisibility(View.VISIBLE);
+        shiftEmptyState.setVisibility(View.GONE);
+        shiftActionButton.setEnabled(!shift.isCompleted());
+
+        populateShiftCard(shift);
+    }
+
+    private void populateShiftCard(ShiftSchedule shift) {
+        Date shiftDate = parseDate(shift.getShiftDate());
+        if (shiftDate != null) {
+            shiftMonthLabel.setText(MONTH_FORMAT.format(shiftDate));
+            shiftDayLabel.setText(DAY_FORMAT.format(shiftDate));
+            shiftWeekdayLabel.setText(WEEKDAY_FORMAT.format(shiftDate));
+        } else {
+            shiftMonthLabel.setText("--");
+            shiftDayLabel.setText("--");
+            shiftWeekdayLabel.setText("--");
+        }
+
+        shiftTimeRange.setText(buildTimeRangeText(shift));
+
+        String location = !TextUtils.isEmpty(shift.getNotes())
+                ? shift.getNotes()
+                : getString(R.string.status_default_location);
+        shiftLocationLabel.setText(location);
+
+        if (shift.isInProgress()) {
+            statusBanner.setText(R.string.status_banner_in_progress);
+            shiftActionButton.setText(R.string.status_end_shift);
+            shiftCountdownLabel.setText(R.string.status_shift_in_progress_message);
+        } else if (shift.isCompleted()) {
+            statusBanner.setText(R.string.status_banner_completed);
+            shiftActionButton.setText(R.string.status_end_shift);
+            shiftActionButton.setEnabled(false);
+            shiftCountdownLabel.setText(R.string.status_shift_completed_message);
+        } else {
+            statusBanner.setText(R.string.status_banner_scheduled);
+            shiftActionButton.setText(R.string.status_start_shift);
+            Date startDateTime = shift.getScheduledStartDateTime();
+            if (startDateTime != null) {
+                shiftCountdownLabel.setText(buildCountdownText(startDateTime));
+            } else {
+                shiftCountdownLabel.setText(R.string.status_starting_placeholder);
+            }
+        }
+    }
+
+    private void setLoading(boolean loading) {
+        loadingIndicator.setVisibility(loading ? View.VISIBLE : View.GONE);
+        shiftActionButton.setEnabled(!loading && currentShift != null && !currentShift.isCompleted());
+    }
+
+    private void setActionInProgress(boolean inProgress) {
+        actionInProgress = inProgress;
+        shiftActionButton.setEnabled(!inProgress && currentShift != null && !currentShift.isCompleted());
+        loadingIndicator.setVisibility(inProgress ? View.VISIBLE : View.GONE);
+    }
+
+    private String buildTimeRangeText(ShiftSchedule shift) {
+        String start = formatTime(shift.getScheduledStart());
+        String end = formatTime(shift.getScheduledEnd());
+        if (TextUtils.isEmpty(start) && TextUtils.isEmpty(end)) {
+            return "--";
+        }
+        if (TextUtils.isEmpty(end)) {
+            return start;
+        }
+        if (TextUtils.isEmpty(start)) {
+            return end;
+        }
+        return start + " - " + end;
+    }
+
+    private String formatTime(@Nullable String value) {
+        if (TextUtils.isEmpty(value)) {
+            return "";
+        }
+        try {
+            Date parsed = SERVER_TIME_FORMAT.parse(sanitizeTime(value));
+            if (parsed != null) {
+                return DISPLAY_TIME_FORMAT.format(parsed);
+            }
+        } catch (ParseException ignored) {
+            // Fallback to raw value below
+        }
+        return value;
+    }
+
+    private String buildCountdownText(Date startDateTime) {
+        long diff = startDateTime.getTime() - System.currentTimeMillis();
+        if (diff <= 0L) {
+            return getString(R.string.status_shift_ready);
+        }
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(diff);
+        long hours = minutes / 60;
+        long remainingMinutes = minutes % 60;
+        String duration;
+        if (hours > 0) {
+            duration = getString(R.string.status_duration_hours_minutes, hours, remainingMinutes);
+        } else {
+            duration = getString(R.string.status_duration_minutes, remainingMinutes);
+        }
+        return getString(R.string.status_starting_soon, duration);
+    }
+
+    @Nullable
+    private Date parseDate(@Nullable String value) {
+        if (TextUtils.isEmpty(value)) {
+            return null;
+        }
+        try {
+            return SERVER_DATE_FORMAT.parse(value.trim());
+        } catch (ParseException ignored) {
+            return null;
+        }
+    }
+
+    private static String sanitizeTime(String raw) {
+        if (raw == null) {
+            return "";
+        }
+        String trimmed = raw.trim();
+        if (trimmed.length() >= 5) {
+            return trimmed.substring(0, 5);
+        }
+        return trimmed;
     }
 }

--- a/app/src/main/java/com/example/deliveryapp/network/ShiftApiService.java
+++ b/app/src/main/java/com/example/deliveryapp/network/ShiftApiService.java
@@ -1,0 +1,38 @@
+package com.example.deliveryapp.network;
+
+import com.example.deliveryapp.network.model.ShiftActionResponse;
+import com.example.deliveryapp.network.model.ShiftSchedule;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.Field;
+import retrofit2.http.FormUrlEncoded;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Query;
+
+public interface ShiftApiService {
+
+    @GET("shift_api.php")
+    Call<List<ShiftSchedule>> getShiftSchedules(
+            @Query("action") String action,
+            @Query("user_id") Integer userId,
+            @Query("start_date") String startDate,
+            @Query("end_date") String endDate
+    );
+
+    @FormUrlEncoded
+    @POST("shift_api.php")
+    Call<ShiftActionResponse> startShift(
+            @Field("action") String action,
+            @Field("shift_id") int shiftId
+    );
+
+    @FormUrlEncoded
+    @POST("shift_api.php")
+    Call<ShiftActionResponse> endShift(
+            @Field("action") String action,
+            @Field("shift_id") int shiftId
+    );
+}

--- a/app/src/main/java/com/example/deliveryapp/network/ShiftRepository.java
+++ b/app/src/main/java/com/example/deliveryapp/network/ShiftRepository.java
@@ -1,0 +1,190 @@
+package com.example.deliveryapp.network;
+
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import com.example.deliveryapp.BuildConfig;
+import com.example.deliveryapp.network.model.ShiftActionResponse;
+import com.example.deliveryapp.network.model.ShiftSchedule;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class ShiftRepository {
+
+    private static final String TAG = "ShiftRepository";
+    private static final String ACTION_LIST = "list";
+    private static final String ACTION_START_SHIFT = "start_shift";
+    private static final String ACTION_END_SHIFT = "end_shift";
+
+    private final ShiftApiService apiService;
+
+    @Nullable
+    private Call<List<ShiftSchedule>> loadCall;
+
+    @Nullable
+    private Call<ShiftActionResponse> actionCall;
+
+    public ShiftRepository() {
+        HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
+        loggingInterceptor.setLevel(BuildConfig.DEBUG
+                ? HttpLoggingInterceptor.Level.BODY
+                : HttpLoggingInterceptor.Level.NONE);
+
+        OkHttpClient client = new OkHttpClient.Builder()
+                .addInterceptor(loggingInterceptor)
+                .build();
+
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(BuildConfig.SHIFT_API_BASE_URL)
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
+
+        apiService = retrofit.create(ShiftApiService.class);
+    }
+
+    public void fetchUpcomingShift(@Nullable Integer userId, final ShiftLoadCallback callback) {
+        cancelLoadCall();
+        loadCall = apiService.getShiftSchedules(ACTION_LIST, userId, null, null);
+        loadCall.enqueue(new Callback<List<ShiftSchedule>>() {
+            @Override
+            public void onResponse(Call<List<ShiftSchedule>> call, Response<List<ShiftSchedule>> response) {
+                if (!response.isSuccessful()) {
+                    callback.onError(extractErrorMessage(response));
+                    return;
+                }
+                List<ShiftSchedule> body = response.body();
+                if (body == null || body.isEmpty()) {
+                    callback.onSuccess(null);
+                    return;
+                }
+                callback.onSuccess(selectUpcomingShift(body));
+            }
+
+            @Override
+            public void onFailure(Call<List<ShiftSchedule>> call, Throwable t) {
+                if (call.isCanceled()) {
+                    return;
+                }
+                callback.onError(t.getMessage() != null ? t.getMessage() : "Request failed");
+            }
+        });
+    }
+
+    public void startShift(int shiftId, final ShiftActionCallback callback) {
+        performShiftAction(apiService.startShift(ACTION_START_SHIFT, shiftId), callback);
+    }
+
+    public void endShift(int shiftId, final ShiftActionCallback callback) {
+        performShiftAction(apiService.endShift(ACTION_END_SHIFT, shiftId), callback);
+    }
+
+    public void cancelAll() {
+        cancelLoadCall();
+        if (actionCall != null) {
+            actionCall.cancel();
+            actionCall = null;
+        }
+    }
+
+    private void performShiftAction(Call<ShiftActionResponse> call, final ShiftActionCallback callback) {
+        cancelActionCall();
+        actionCall = call;
+        actionCall.enqueue(new Callback<ShiftActionResponse>() {
+            @Override
+            public void onResponse(Call<ShiftActionResponse> call, Response<ShiftActionResponse> response) {
+                if (!response.isSuccessful()) {
+                    callback.onCompleted(false, extractErrorMessage(response));
+                    return;
+                }
+                ShiftActionResponse body = response.body();
+                if (body == null) {
+                    callback.onCompleted(false, "Empty server response");
+                    return;
+                }
+                callback.onCompleted(body.isSuccess(), body.getMessage());
+            }
+
+            @Override
+            public void onFailure(Call<ShiftActionResponse> call, Throwable t) {
+                if (call.isCanceled()) {
+                    return;
+                }
+                callback.onCompleted(false, t.getMessage() != null ? t.getMessage() : "Request failed");
+            }
+        });
+    }
+
+    private void cancelLoadCall() {
+        if (loadCall != null) {
+            loadCall.cancel();
+            loadCall = null;
+        }
+    }
+
+    private void cancelActionCall() {
+        if (actionCall != null) {
+            actionCall.cancel();
+            actionCall = null;
+        }
+    }
+
+    @Nullable
+    private ShiftSchedule selectUpcomingShift(List<ShiftSchedule> schedules) {
+        if (schedules.isEmpty()) {
+            return null;
+        }
+        Collections.sort(schedules, new Comparator<ShiftSchedule>() {
+            @Override
+            public int compare(ShiftSchedule first, ShiftSchedule second) {
+                Date firstDate = first.getScheduledStartDateTime();
+                Date secondDate = second.getScheduledStartDateTime();
+                if (firstDate == null && secondDate == null) {
+                    return 0;
+                }
+                if (firstDate == null) {
+                    return 1;
+                }
+                if (secondDate == null) {
+                    return -1;
+                }
+                return firstDate.compareTo(secondDate);
+            }
+        });
+        return schedules.get(0);
+    }
+
+    private String extractErrorMessage(Response<?> response) {
+        try {
+            if (response.errorBody() != null) {
+                return response.errorBody().string();
+            }
+        } catch (IOException e) {
+            Log.w(TAG, "Failed to read error body", e);
+        }
+        return "Unexpected server response";
+    }
+
+    public interface ShiftLoadCallback {
+        void onSuccess(@Nullable ShiftSchedule upcomingShift);
+
+        void onError(String message);
+    }
+
+    public interface ShiftActionCallback {
+        void onCompleted(boolean success, @Nullable String message);
+    }
+}

--- a/app/src/main/java/com/example/deliveryapp/network/model/ShiftActionResponse.java
+++ b/app/src/main/java/com/example/deliveryapp/network/model/ShiftActionResponse.java
@@ -1,0 +1,33 @@
+package com.example.deliveryapp.network.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import androidx.annotation.Nullable;
+
+public class ShiftActionResponse {
+
+    @SerializedName("success")
+    private boolean success;
+
+    @SerializedName("message")
+    @Nullable
+    private String message;
+
+    @SerializedName("shift")
+    @Nullable
+    private ShiftSchedule shift;
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    @Nullable
+    public String getMessage() {
+        return message;
+    }
+
+    @Nullable
+    public ShiftSchedule getShift() {
+        return shift;
+    }
+}

--- a/app/src/main/java/com/example/deliveryapp/network/model/ShiftSchedule.java
+++ b/app/src/main/java/com/example/deliveryapp/network/model/ShiftSchedule.java
@@ -1,0 +1,170 @@
+package com.example.deliveryapp.network.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Objects;
+
+import androidx.annotation.Nullable;
+
+public class ShiftSchedule {
+
+    @SerializedName("Shift_ID")
+    private int shiftId;
+
+    @SerializedName("User_ID")
+    private Integer userId;
+
+    @SerializedName("Shift_Date")
+    private String shiftDate;
+
+    @SerializedName("Scheduled_Start")
+    private String scheduledStart;
+
+    @SerializedName("Scheduled_End")
+    private String scheduledEnd;
+
+    @SerializedName("Actual_Start")
+    private String actualStart;
+
+    @SerializedName("Actual_End")
+    private String actualEnd;
+
+    @SerializedName("Status")
+    private String status;
+
+    @SerializedName("Notes")
+    private String notes;
+
+    @SerializedName("Name")
+    private String staffName;
+
+    public int getShiftId() {
+        return shiftId;
+    }
+
+    @Nullable
+    public Integer getUserId() {
+        return userId;
+    }
+
+    @Nullable
+    public String getShiftDate() {
+        return shiftDate;
+    }
+
+    @Nullable
+    public String getScheduledStart() {
+        return scheduledStart;
+    }
+
+    @Nullable
+    public String getScheduledEnd() {
+        return scheduledEnd;
+    }
+
+    @Nullable
+    public String getActualStart() {
+        return actualStart;
+    }
+
+    @Nullable
+    public String getActualEnd() {
+        return actualEnd;
+    }
+
+    @Nullable
+    public String getStatus() {
+        return status;
+    }
+
+    @Nullable
+    public String getNotes() {
+        return notes;
+    }
+
+    @Nullable
+    public String getStaffName() {
+        return staffName;
+    }
+
+    public boolean isInProgress() {
+        return !isNullOrEmpty(actualStart) && isNullOrEmpty(actualEnd);
+    }
+
+    public boolean isCompleted() {
+        return !isNullOrEmpty(actualStart) && !isNullOrEmpty(actualEnd);
+    }
+
+    public boolean isScheduled() {
+        return isNullOrEmpty(actualStart);
+    }
+
+    @Nullable
+    public Date getScheduledStartDateTime() {
+        if (isNullOrEmpty(shiftDate) || isNullOrEmpty(scheduledStart)) {
+            return null;
+        }
+
+        try {
+            Date datePart = createDateFormat().parse(shiftDate.trim());
+            Date timePart = createTimeFormat().parse(sanitizeTime(scheduledStart));
+            if (datePart == null || timePart == null) {
+                return null;
+            }
+            Calendar result = Calendar.getInstance();
+            result.setTime(datePart);
+
+            Calendar timeCalendar = Calendar.getInstance();
+            timeCalendar.setTime(timePart);
+
+            result.set(Calendar.HOUR_OF_DAY, timeCalendar.get(Calendar.HOUR_OF_DAY));
+            result.set(Calendar.MINUTE, timeCalendar.get(Calendar.MINUTE));
+            result.set(Calendar.SECOND, 0);
+            result.set(Calendar.MILLISECOND, 0);
+            return result.getTime();
+        } catch (ParseException ignored) {
+            return null;
+        }
+    }
+
+    private static boolean isNullOrEmpty(@Nullable String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private static String sanitizeTime(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() >= 5) {
+            return trimmed.substring(0, 5);
+        }
+        return trimmed;
+    }
+
+    private static SimpleDateFormat createDateFormat() {
+        return new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+    }
+
+    private static SimpleDateFormat createTimeFormat() {
+        return new SimpleDateFormat("HH:mm", Locale.US);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ShiftSchedule)) return false;
+        ShiftSchedule that = (ShiftSchedule) o;
+        return shiftId == that.shiftId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shiftId);
+    }
+}

--- a/app/src/main/res/layout/activity_status.xml
+++ b/app/src/main/res/layout/activity_status.xml
@@ -35,11 +35,11 @@
         android:id="@+id/statusBanner"
         android:layout_width="match_parent"
         android:layout_height="40dp"
-        android:text="Not Working"
-        android:gravity="center"
+        android:layout_below="@id/topBar"
         android:background="#EEEEEE"
-        android:textColor="#555555"
-        android:layout_below="@id/topBar" />
+        android:gravity="center"
+        android:text="@string/status_banner_not_working"
+        android:textColor="#555555" />
 
     <!-- Scrollable content -->
     <ScrollView
@@ -82,6 +82,7 @@
 
             <!-- Shift Card -->
             <LinearLayout
+                android:id="@+id/shiftCard"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
@@ -107,24 +108,27 @@
                         android:layout_marginEnd="12dp">
 
                         <TextView
+                            android:id="@+id/shiftMonthLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Sep"
+                            android:text="--"
                             android:textColor="#FF9800"
                             android:textSize="12sp"/>
 
                         <TextView
+                            android:id="@+id/shiftDayLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="3"
+                            android:text="--"
                             android:textStyle="bold"
                             android:textSize="22sp"
                             android:textColor="#000000"/>
 
                         <TextView
+                            android:id="@+id/shiftWeekdayLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Wed"
+                            android:text="--"
                             android:textSize="12sp"
                             android:textColor="#777777"/>
                     </LinearLayout>
@@ -136,24 +140,27 @@
                         android:orientation="vertical">
 
                         <TextView
+                            android:id="@+id/shiftTimeRange"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="11:00 - 5:00"
+                            android:text="--"
                             android:textStyle="bold"
                             android:textSize="16sp"
                             android:textColor="#000000"/>
 
                         <TextView
+                            android:id="@+id/shiftLocationLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Hagonoy Bulacan"
+                            android:text="--"
                             android:textSize="14sp"
                             android:textColor="#555555"/>
 
                         <TextView
+                            android:id="@+id/shiftCountdownLabel"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:text="Starting in 16mins"
+                            android:text="@string/status_starting_placeholder"
                             android:textColor="#4CAF50"
                             android:textSize="12sp"/>
                     </LinearLayout>
@@ -161,14 +168,36 @@
 
                 <!-- Ready Button -->
                 <Button
+                    android:id="@+id/btnShiftAction"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Start Shift Now"
-                    android:backgroundTint="#FF3B30"
-                    android:textColor="#FFFFFF"
                     android:layout_marginTop="12dp"
-                    android:padding="10dp"/>
+                    android:backgroundTint="#FF3B30"
+                    android:padding="10dp"
+                    android:text="@string/status_start_shift"
+                    android:textColor="#FFFFFF"/>
+
+                <ProgressBar
+                    android:id="@+id/shiftLoadingIndicator"
+                    style="?android:attr/progressBarStyleSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="8dp"
+                    android:visibility="gone" />
             </LinearLayout>
+
+            <TextView
+                android:id="@+id/shiftEmptyState"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="8dp"
+                android:gravity="center"
+                android:text="@string/status_no_shift"
+                android:textColor="#777777"
+                android:textSize="14sp"
+                android:visibility="gone" />
         </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,19 @@
 <resources>
     <string name="app_name">Delivery app</string>
+    <string name="status_banner_not_working">Not Working</string>
+    <string name="status_banner_in_progress">Shift In Progress</string>
+    <string name="status_banner_completed">Shift Completed</string>
+    <string name="status_banner_scheduled">Shift Scheduled</string>
+    <string name="status_start_shift">Start Shift</string>
+    <string name="status_end_shift">End Shift</string>
+    <string name="status_no_shift">You have no shifts scheduled today.</string>
+    <string name="status_loading_error">Unable to load shift information. Pull to refresh or try again later.</string>
+    <string name="status_starting_placeholder">Checking schedule…</string>
+    <string name="status_shift_ready">Ready to start</string>
+    <string name="status_duration_hours_minutes">%1$d hr %2$d min</string>
+    <string name="status_duration_minutes">%1$d min</string>
+    <string name="status_starting_soon">Starting in %1$s</string>
+    <string name="status_default_location">Cindy&#39;s Bakeshop HQ</string>
+    <string name="status_shift_completed_message">Shift completed</string>
+    <string name="status_shift_in_progress_message">Shift in progress</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ material = "1.12.0"
 activity = "1.10.1"
 constraintlayout = "2.2.1"
 firebaseBom = "33.5.1"
+retrofit = "2.11.0"
+okhttp = "4.12.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -19,6 +21,9 @@ activity = { group = "androidx.activity", name = "activity", version.ref = "acti
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add Retrofit/OkHttp dependencies and internet permission so the app can reach the shift API
- implement a reusable ShiftRepository with Retrofit service models to include the required `action` parameter when hitting the PHP endpoints
- refresh the status screen UI to load upcoming shifts from the server, handle start/end actions, and show appropriate loading and empty states

## Testing
- ./gradlew assembleDebug *(fails: Android SDK not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e867d37dec8324aac50403f52e4244